### PR TITLE
fix(exoplayer): handle multiple discontinuity events

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -622,6 +622,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
             queue.advancePlayingPeriod();
           }
           MediaPeriodHolder newPlayingPeriodHolder = checkNotNull(queue.getPlayingPeriod());
+          // Send already pending updates if needed before making further changes to PlaybackInfo.
+          maybeNotifyPlaybackInfoChanged();
           playbackInfo =
               handlePositionDiscontinuity(
                   newPlayingPeriodHolder.info.id,


### PR DESCRIPTION
Send pending updates before adding discontinuity for error

When handling a playback error that originates from a future item in the playlist, we added support for jumping to that item first, ensuring the errors 'happen' for the right 'current item'. See 79b688e.

However, when we add this new position discontinuity to the playback state, there may already be other position discontinuities pending from other parts of the code that executed before the error. As we can't control that in this case (because it's part of a generic try/catch block), we need to send any pending updates first before handling the new change.

Issue: https://github.com/androidx/media/issues/1483
#cherrypick
Refs: https://github.com/androidx/media/commit/727645179b3c26e495540f4445216fd035cc7654 PiperOrigin-RevId: 646968309

